### PR TITLE
Change price scanner implementation

### DIFF
--- a/data/found_combos.txt
+++ b/data/found_combos.txt
@@ -1,0 +1,2 @@
+	Combo: 7, mixed fruit (2.15)
+	Combo: 1, mixed fruit (2.15); 2, hot wings (3.55); 1, sampler plate (5.8)

--- a/data/found_combos.txt
+++ b/data/found_combos.txt
@@ -1,2 +1,0 @@
-	Combo: 7, mixed fruit (2.15)
-	Combo: 1, mixed fruit (2.15); 2, hot wings (3.55); 1, sampler plate (5.8)

--- a/lib/data_preparation.rb
+++ b/lib/data_preparation.rb
@@ -3,7 +3,7 @@ class DataPreparation
   end
 
   def assign_target_price(input)
-    @_target = convert_to_float(input.first)
+    @_target = convert_to_integer(input.first)
   end
 
   def split_data(input)

--- a/lib/data_preparation.rb
+++ b/lib/data_preparation.rb
@@ -10,17 +10,23 @@ class DataPreparation
     input[1..-1].map { |item| item.split(',') }
   end
 
+
+  def convert_to_float(element)
+    element.gsub(/[^\d\.]/, '').to_f
+  end
+
+  def convert_to_integer(element)
+    (convert_to_float(element) * 100).to_i
+  end
+
   def format_split_data(input)
-    split_data(input).map { |item| [ item[0], convert_to_float(item[1]) ] }
+    split_data(input).map { |item| [ item[0], convert_to_integer(item[1]) ] }
   end
 
   def assign_items_with_prices(input)
     @_items_prices = format_split_data(input).map { |item| Hash[*item] }
   end
 
-  def convert_to_float(element)
-    element.gsub(/[^\d\.]/, '').to_f
-  end
 
   private
     def target

--- a/lib/price_scanner.rb
+++ b/lib/price_scanner.rb
@@ -51,10 +51,6 @@ class PriceScanner
     (index % item.values.first) == 0
   end
 
-  def divide_index_by_item_price(index, item)
-    index/(item.values.first)
-  end
-
   def set_combo_for_index_divisible_by_item_price(index, item)
     increment_counter(index)
     q = divide_index_by_item_price(index, item)
@@ -73,46 +69,12 @@ class PriceScanner
     combos[diff].each do |combo|
       increment_counter(index)
       if item_already_included_in_combo?(combo, item)
-        combos[index] << determine_if_update(combo, item, index)
+        combos[index] << determine_retain_or_update_combo(combo, item, index)
       else
         combos[index] << [ combo, { 1 => item } ].flatten
       end
     end
     combos[index]
-  end
-
-  def determine_if_update(combo, item, index)
-    new_combo = update_combo(combo, item)
-    new_total_price = get_price(new_combo)
-    if new_total_price > index
-      combo
-    else
-      new_combo
-    end
-  end
-
-  def get_price(combo)
-    combo.reduce(0) { |sum, item| sum += (item.keys.first * item.values.first.values.first) }
-  end
-
-  def update_combo(combo, item)
-    new_combo = []
-    new_combo.replace(combo)
-    new_q = increment_quantity(new_combo, item)
-    remove_old_option(arr, item)
-    arr << { new_q => item }
-  end
-
-  def item_already_included_in_combo?(combo, item)
-    combo.any? { |option| option.values.include?(item) }
-  end
-
-  def remove_old_option(combo, item)
-    combo.delete_if { |option| option.values.include?(item) }
-  end
-
-  def increment_quantity(combo, item)
-    combo.find { |option| option.values.include?(item) }.keys.first + 1
   end
 
   def assign_combos_at_different_values
@@ -149,5 +111,50 @@ class PriceScanner
 
     def target_price_items_combos
       @_target_price_items_combos
+    end
+
+    def divide_index_by_item_price(index, item)
+      index/(item.values.first)
+    end
+
+    def item_already_included_in_combo?(combo, item)
+      combo.any? { |option| option.values.include?(item) }
+    end
+
+    def determine_retain_or_update_combo(combo, item, index)
+      new_combo = set_new_combo(combo, item)
+
+      if new_price_greater_than_index?(new_combo, index)
+        combo
+      else
+        new_combo
+      end
+    end
+
+    def set_new_combo(combo, item)
+      new_combo = initialize_combo(combo)
+      new_q     = increment_quantity(new_combo, item)
+      remove_old_option(new_combo, item)
+      new_combo << { new_q => item }
+    end
+
+    def initialize_combo(combo)
+      Array.new.replace(combo)
+    end
+
+    def increment_quantity(combo, item)
+      combo.find { |option| option.values.include?(item) }.keys.first + 1
+    end
+
+    def remove_old_option(combo, item)
+      combo.delete_if { |option| option.values.include?(item) }
+    end
+
+    def new_price_greater_than_index?(new_combo, index)
+      get_price(new_combo) > index
+    end
+
+    def get_price(combo)
+      combo.reduce(0) { |sum, item| sum += (item.keys.first * item.values.first.values.first) }
     end
 end

--- a/lib/price_scanner.rb
+++ b/lib/price_scanner.rb
@@ -104,7 +104,6 @@ class PriceScanner
     @_target_price_items_combos = find_target_price_items_combos
   end
 
-
   def target_price_items_combos_exist?
     if target_price_items_combos.empty?
       return "\tUnfortunately, there is no combination of dishes that sum to the target price."

--- a/lib/price_scanner.rb
+++ b/lib/price_scanner.rb
@@ -73,7 +73,7 @@ class PriceScanner
     combos[diff].each do |combo|
       increment_counter(index)
       if item_already_included_in_combo?(combo, item)
-        combos[index] << update_combo(combo, item)
+        combos[index] << determine_if_update(combo, item, index)
       else
         combos[index] << [ combo, { 1 => item } ].flatten
       end
@@ -81,10 +81,26 @@ class PriceScanner
     combos[index]
   end
 
+  def determine_if_update(combo, item, index)
+    new_combo = update_combo(combo, item)
+    new_total_price = get_price(new_combo)
+    if new_total_price > index
+      combo
+    else
+      new_combo
+    end
+  end
+
+  def get_price(combo)
+    combo.reduce(0) { |sum, item| sum += (item.keys.first * item.values.first.values.first) }
+  end
+
   def update_combo(combo, item)
-    new_q = increment_quantity(combo, item)
-    remove_old_option(combo, item)
-    combo << { new_q => item }
+    new_combo = []
+    new_combo.replace(combo)
+    new_q = increment_quantity(new_combo, item)
+    remove_old_option(arr, item)
+    arr << { new_q => item }
   end
 
   def item_already_included_in_combo?(combo, item)

--- a/lib/price_scanner.rb
+++ b/lib/price_scanner.rb
@@ -44,15 +44,11 @@ class PriceScanner
   end
 
   def find_target_price_items_combos
-    combos[target]
+    @_target_price_items_combos = combos[target]
   end
 
   def is_divisible?(index, item)
     (index % item.values.first) == 0
-  end
-
-  def divide_index_by_item_price(index, item)
-    index/(item.values.first)
   end
 
   def set_combo_for_index_divisible_by_item_price(index, item)
@@ -73,7 +69,7 @@ class PriceScanner
     combos[diff].each do |combo|
       increment_counter(index)
       if item_already_included_in_combo?(combo, item)
-        combos[index] << determine_if_update(combo, item, index)
+        combos[index] << determine_retain_or_update_combo(combo, item, index)
       else
         combos[index] << [ combo, { 1 => item } ].flatten
       end
@@ -81,43 +77,9 @@ class PriceScanner
     combos[index]
   end
 
-  def determine_if_update(combo, item, index)
-    new_combo = update_combo(combo, item)
-    new_total_price = get_price(new_combo)
-    if new_total_price > index
-      combo
-    else
-      new_combo
-    end
-  end
-
-  def get_price(combo)
-    combo.reduce(0) { |sum, item| sum += (item.keys.first * item.values.first.values.first) }
-  end
-
-  def update_combo(combo, item)
-    new_combo = []
-    new_combo.replace(combo)
-    new_q = increment_quantity(new_combo, item)
-    remove_old_option(arr, item)
-    arr << { new_q => item }
-  end
-
-  def item_already_included_in_combo?(combo, item)
-    combo.any? { |option| option.values.include?(item) }
-  end
-
-  def remove_old_option(combo, item)
-    combo.delete_if { |option| option.values.include?(item) }
-  end
-
-  def increment_quantity(combo, item)
-    combo.find { |option| option.values.include?(item) }.keys.first + 1
-  end
-
   def assign_combos_at_different_values
     find_up_to_target_price_combinations
-    @_target_price_items_combos = find_target_price_items_combos
+    find_target_price_items_combos
   end
 
   def target_price_items_combos_exist?
@@ -149,5 +111,50 @@ class PriceScanner
 
     def target_price_items_combos
       @_target_price_items_combos
+    end
+
+    def divide_index_by_item_price(index, item)
+      index/(item.values.first)
+    end
+
+    def item_already_included_in_combo?(combo, item)
+      combo.any? { |option| option.values.include?(item) }
+    end
+
+    def determine_retain_or_update_combo(combo, item, index)
+      new_combo = set_new_combo(combo, item)
+
+      if new_price_greater_than_index?(new_combo, index)
+        combo
+      else
+        new_combo
+      end
+    end
+
+    def set_new_combo(combo, item)
+      new_combo = initialize_combo(combo)
+      new_q     = increment_quantity(new_combo, item)
+      remove_old_option(new_combo, item)
+      new_combo << { new_q => item }
+    end
+
+    def initialize_combo(combo)
+      Array.new.replace(combo)
+    end
+
+    def increment_quantity(combo, item)
+      combo.find { |option| option.values.include?(item) }.keys.first + 1
+    end
+
+    def remove_old_option(combo, item)
+      combo.delete_if { |option| option.values.include?(item) }
+    end
+
+    def new_price_greater_than_index?(new_combo, index)
+      get_price(new_combo) > index
+    end
+
+    def get_price(combo)
+      combo.reduce(0) { |sum, item| sum += (item.keys.first * item.values.first.values.first) }
     end
 end

--- a/lib/price_scanner.rb
+++ b/lib/price_scanner.rb
@@ -72,8 +72,31 @@ class PriceScanner
   def set_combos_for_index_with_combos_at_difference(diff, index, item)
     combos[diff].each do |combo|
       increment_counter(index)
-      combos[index] << [ combo, { 1 => item} ]
+      if item_already_included_in_combo?(combo, item)
+        combos[index] << update_combo(combo, item)
+      else
+        combos[index] << [ combo, { 1 => item } ].flatten
+      end
     end
+    combos[index]
+  end
+
+  def update_combo(combo, item)
+    new_q = increment_quantity(combo, item)
+    remove_old_option(combo, item)
+    combo << { new_q => item }
+  end
+
+  def item_already_included_in_combo?(combo, item)
+    combo.any? { |option| option.values.include?(item) }
+  end
+
+  def remove_old_option(combo, item)
+    combo.delete_if { |option| option.values.include?(item) }
+  end
+
+  def increment_quantity(combo, item)
+    combo.find { |option| option.values.include?(item) }.keys.first + 1
   end
 
   def assign_combos_at_different_values
@@ -81,19 +104,20 @@ class PriceScanner
     @_target_price_items_combos = find_target_price_items_combos
   end
 
-  #
-  # def target_price_items_combos_exist?
-  #   if target_price_items_combos.nil?
-  #     return "\tUnfortunately, there is no combination of dishes that sum to the target price."
-  #   else
-  #     target_price_items_combos
-  #   end
-  # end
-  #
-  # def analyze_input
-  #   assign_sets_of_items_and_prices
-  #   target_price_items_combos_exist?
-  # end
+
+  def target_price_items_combos_exist?
+    if target_price_items_combos.empty?
+      return "\tUnfortunately, there is no combination of dishes that sum to the target price."
+    else
+      target_price_items_combos
+    end
+  end
+
+  def analyze_input
+    set_up
+    assign_combos_at_different_values
+    target_price_items_combos_exist?
+  end
 
   private
     def pruned_data

--- a/lib/result_presenter.rb
+++ b/lib/result_presenter.rb
@@ -33,6 +33,6 @@ class ResultPresenter
   end
 
   def format_item_price(item)
-    (item.values.first.values.first/100).to_f
+    item.values.first.values.first/100.to_f
   end
 end

--- a/lib/result_presenter.rb
+++ b/lib/result_presenter.rb
@@ -19,6 +19,20 @@ class ResultPresenter
   end
 
   def format_combo(combo)
-    combo.map { |item| "#{item.keys.first}, #{item.values.first}"}.join("; ")
+    combo.map do |item|
+      "#{format_quantity(item)}, #{format_item_name(item)} (#{format_item_price(item)})"
+    end.join("; ")
+  end
+
+  def format_quantity(item)
+    item.keys.first
+  end
+
+  def format_item_name(item)
+    item.values.first.keys.first
+  end
+
+  def format_item_price(item)
+    (item.values.first.values.first/100).to_f
   end
 end

--- a/spec/models/data_preparation_spec.rb
+++ b/spec/models/data_preparation_spec.rb
@@ -38,4 +38,16 @@ describe "DataPreparation object" do
       expect( result ).not_to eq( dollar_string )
     end
   end
+
+  context "#convert_to_integer" do
+    it "can format converted float to integer" do
+      content       = DataPreparation.new
+      dollar_string = "$5.00"
+      result        = content.convert_to_integer(dollar_string)
+
+      expect( result.class ).to eq( Fixnum )
+      expect( result ).not_to eq( dollar_string )
+      expect( result ).to eq( 500 )
+    end
+  end
 end

--- a/spec/models/matchmaker_spec.rb
+++ b/spec/models/matchmaker_spec.rb
@@ -28,7 +28,7 @@ describe "Matchmaker object" do
     end
 
     it "can prepare content with setting target and items-prices values" do
-      expect( prep_content.send(:target) ).to eq( 500 )
+      expect( prep_content.send(:target) ).to eq( 515 )
       expect( prep_content.send(:items_prices) ).to eq ( [{"mixed fruit"=>215}, {"golden omelette"=>300}, {"tatter tots"=>200}, {"orange juice"=>200}] )
     end
 
@@ -37,7 +37,7 @@ describe "Matchmaker object" do
     end
 
     it "can return formatted results after scanning input" do
-      expected_format = "\tCombo: 1, golden omelette (3.0); 1, tatter tots (2.0)\n\tCombo: 1, golden omelette (3.0); 1, orange juice (2.0)"
+      expected_format = "\tCombo: 1, mixed fruit (2.15); 1, golden omelette (3.0)"
 
       expect( formatted_result ).to eq( expected_format )
     end
@@ -51,6 +51,18 @@ describe "Matchmaker object" do
       results      = matchmaker.make_analysis
 
       expect( results ).to eq( sad_result )
+    end
+  end
+
+  context "another case" do
+    it "returns happy result with another data set" do
+      test_file       = 'spec/support/menu.txt'
+      parsed_input    = parse_data_file(test_file)
+      matchmaker      = Matchmaker.new(parsed_input)
+      results         = matchmaker.make_analysis
+      expected_result = "\tCombo: 7, mixed fruit (2.15)\n\tCombo: 1, mixed fruit (2.15); 2, hot wings (3.55); 1, sampler plate (5.8)"
+
+      expect( results ).to eq( expected_result )
     end
   end
 end

--- a/spec/models/matchmaker_spec.rb
+++ b/spec/models/matchmaker_spec.rb
@@ -28,8 +28,8 @@ describe "Matchmaker object" do
     end
 
     it "can prepare content with setting target and items-prices values" do
-      expect( prep_content.send(:target) ).to eq( 5.0 )
-      expect( prep_content.send(:items_prices) ).to eq ( [{"mixed fruit"=>2.15}, {"golden omelette"=>3.0}, {"tatter tots"=>2.0}, {"orange juice"=>2.0}] )
+      expect( prep_content.send(:target) ).to eq( 500 )
+      expect( prep_content.send(:items_prices) ).to eq ( [{"mixed fruit"=>215}, {"golden omelette"=>300}, {"tatter tots"=>200}, {"orange juice"=>200}] )
     end
 
     it "can return unformatted results after data preparation" do
@@ -37,7 +37,7 @@ describe "Matchmaker object" do
     end
 
     it "can return formatted results after scanning input" do
-      expected_format = "\tCombo: golden omelette, 3.0; tatter tots, 2.0\n\tCombo: golden omelette, 3.0; orange juice, 2.0"
+      expected_format = "\tCombo: 1, golden omelette (3.0); 1, tatter tots (2.0)\n\tCombo: 1, golden omelette (3.0); 1, orange juice (2.0)"
 
       expect( formatted_result ).to eq( expected_format )
     end

--- a/spec/models/price_scanner_spec.rb
+++ b/spec/models/price_scanner_spec.rb
@@ -34,31 +34,99 @@ describe "PriceScanner object" do
     end
   end
 
-  context "find matching target price combos" do
-    before(:each) do
-      data             = set_items_and_prices
-      scanner.prune_items_with_prices_exceeding_target_price(data)
-      @all_combos      = scanner.find_all_combos
+  context "set combos and value_combos_counter collections" do
+    it "can set a combos collection for all possible collections leading up to target value" do
+      combos = scanner.set_combinations
+
+      expect( combos.class ).to eq( Array )
+      expect( combos.length - 1 ).to eq( target )
+      expect( scanner.send(:combos) ).to eq( combos )
     end
 
-    it "can return a collection of prices of all unique combinations" do
-      expect( @all_combos.size ).to eq( 63 )
-    end
+    it "can set a value_combos_counter that counts number of combos per value leading up to target value" do
+      values_combos_counter = scanner.set_values_combos_counter
 
-    it "can return a collection of prices that sum exactly to target price" do
-      matched_price_combos = scanner.find_target_price_items_combos(@all_combos)
-      expected_matches     = [[{"golden omelette"=>3.0}, {"tatter tots"=>2.0}],
-                              [{"golden omelette"=>3.0}, {"wedged potatoes"=>2.0}],
-                              [{"golden omelette"=>3.0}, {"orange juice"=>1.0}, {"morning salad"=>1.0}],
-                              [{"tatter tots"=>2.0}, {"orange juice"=>1.0}, {"wedged potatoes"=>2.0}],
-                              [{"tatter tots"=>2.0}, {"morning salad"=>1.0}, {"wedged potatoes"=>2.0}]]
-
-      expect( matched_price_combos.count ).to eq( 5 )
-      expect( matched_price_combos ).to eq( expected_matches )
+      expect( values_combos_counter.class ).to eq( Array )
+      expect( values_combos_counter.length - 1 ).to eq( target )
+      expect( scanner.send(:values_combos_counter) ).to eq( values_combos_counter )
     end
   end
 
-  context "#target_item_combos_exist?" do
+  context "#increment_counter" do
+    it "increments the values_combos_counter by 1" do
+      scanner.set_values_combos_counter
+
+      values_combos_counter = scanner.send(:values_combos_counter)
+      index                 = target
+
+      expect( values_combos_counter[index][index] ).to eq( 0 )
+
+      expect { scanner.increment_counter(index) }.to change{ values_combos_counter[index][index] }.by(1)
+    end
+  end
+
+  context "find matching target price combos" do
+    attr_reader :combos,
+                :data
+
+    before(:each) do
+      @data = set_items_and_prices
+      scanner.prune_items_with_prices_exceeding_target_price(data)
+      scanner.set_up
+      @combos = scanner.send(:combos)
+    end
+
+    it "can set a combination for an index number that is divisible by item's price" do
+      index = 200
+      item  = data[2]
+
+      expect( scanner.is_divisible?(index, item) ).to eq( true )
+
+      result = scanner.set_combo_for_index_divisible_by_item_price(index, item)
+
+      expect( result ).to eq( [ [{1=>{"tatter tots"=>200}}] ] )
+      expect( result ).to eq( combos[index] )
+    end
+
+    it "can set combinations for an index based on difference between index and item price" do
+      index = 300
+      item  = data[2]
+      diff  = scanner.get_difference(index, item)
+
+      expect( scanner.is_greater_than_item_price?(index, item) ).to eq( true )
+
+      result = scanner.set_combos_for_index_with_combos_at_difference(diff, index, item)
+
+      expect( result ).to eq( "something" )
+      expect( result ).to eq( combos[index] )
+    end
+  end
+
+  # xcontext "find matching target price combos" do
+  #   before(:each) do
+  #     data             = set_items_and_prices
+  #     scanner.prune_items_with_prices_exceeding_target_price(data)
+  #     @all_combos      = scanner.find_all_combos
+  #   end
+  #
+  #   it "can return a collection of prices of all unique combinations" do
+  #     expect( @all_combos.size ).to eq( 63 )
+  #   end
+  #
+  #   it "can return a collection of prices that sum exactly to target price" do
+  #     matched_price_combos = scanner.find_target_price_items_combos(@all_combos)
+  #     expected_matches     = [[{"golden omelette"=>300}, {"tatter tots"=>200}],
+  #                             [{"golden omelette"=>300}, {"wedged potatoes"=>200}],
+  #                             [{"golden omelette"=>300}, {"orange juice"=>100}, {"morning salad"=>100}],
+  #                             [{"tatter tots"=>200}, {"orange juice"=>100}, {"wedged potatoes"=>200}],
+  #                             [{"tatter tots"=>200}, {"morning salad"=>100}, {"wedged potatoes"=>200}]]
+  #
+  #     expect( matched_price_combos.count ).to eq( 5 )
+  #     expect( matched_price_combos ).to eq( expected_matches )
+  #   end
+  # end
+
+  xcontext "#target_item_combos_exist?" do
     it "can return sets of items after finding price combos with a different data set" do
       scanner_two   = PriceScanner.new(set_another_target)
       data_set_two  = set_more_items_and_prices
@@ -66,11 +134,11 @@ describe "PriceScanner object" do
       scanner_two.assign_sets_of_items_and_prices
       matched_items = scanner_two.target_price_items_combos_exist?
 
-      expect( matched_items ).to eq( [ [{ "sampler plate"=>5.8 }, { "larger sampler plate"=>9.25 }] ] )
+      expect( matched_items ).to eq( [ [{ "sampler plate"=>580 }, { "larger sampler plate"=>925 }] ] )
     end
   end
 
-  context "it cannot find a match and #analyze_input" do
+  xcontext "it cannot find a match and #analyze_input" do
     it "returns a sad message informing that no matches were found against target price" do
       sad_message    = "\tUnfortunately, there is no combination of dishes that sum to the target price."
       scanner_three  = PriceScanner.new(set_sample_target)

--- a/spec/models/price_scanner_spec.rb
+++ b/spec/models/price_scanner_spec.rb
@@ -141,7 +141,7 @@ describe "PriceScanner object" do
       matched_items   = scanner_two.target_price_items_combos_exist?
       expected_result = [
                           [{7=>{"mixed fruit"=>215}}],
-                          [{1=>{"mixed fruit"=>215}}, {3=>{"hot wings"=>355}}, {1=>{"sampler plate"=>580}}],
+                          [{1=>{"mixed fruit"=>215}}, {2=>{"hot wings"=>355}}, {1=>{"sampler plate"=>580}}],
                           [{1=>{"sampler plate"=>580}}, {1=>{"larger sampler plate"=>925}}]
                         ]
 

--- a/spec/models/result_presenter_spec.rb
+++ b/spec/models/result_presenter_spec.rb
@@ -13,8 +13,8 @@ describe "ResultPresenter object" do
   context "#happy_path" do
     it "can format data when there are results" do
       result_presenter = ResultPresenter.new(happy_result)
-      result = result_presenter.happy_path
-      expected_format  = "\tCombo: tatter tots, 2.0; golden omelette, 3.0\n\tCombo: orange juice, 1.0; morning salad, 1.0; golden omelette, 3.0"
+      result           = result_presenter.happy_path
+      expected_format  = "\tCombo: 1, golden omelette (3.0); 1, tatter tots (2.0)\n\tCombo: 5, orange juice (1.0)\n\tCombo: 5, morning salad (1.0)"
 
       expect( result ).to eq( expected_format)
     end
@@ -24,7 +24,7 @@ describe "ResultPresenter object" do
     it "can format data based on #happy_path" do
       result_presenter = ResultPresenter.new(happy_result)
       result_presenter.determine_format
-      expected_format  = "\tCombo: tatter tots, 2.0; golden omelette, 3.0\n\tCombo: orange juice, 1.0; morning salad, 1.0; golden omelette, 3.0"
+      expected_format  = "\tCombo: 1, golden omelette (3.0); 1, tatter tots (2.0)\n\tCombo: 5, orange juice (1.0)\n\tCombo: 5, morning salad (1.0)"
 
       expect( result_presenter.formatted_result ).to eq( expected_format)
     end

--- a/spec/support/another_sample_menu.txt
+++ b/spec/support/another_sample_menu.txt
@@ -1,7 +1,7 @@
 $15.05
-mixed fruit,$2.15
-french fries,$2.75
-side salad,$3.35
-hot wings,$3.55
-mozzarella sticks,$4.20
-sampler plate,$5.80
+mixed fruit,$12.15
+french fries,$12.75
+side salad,$13.35
+hot wings,$13.55
+mozzarella sticks,$14.20
+sampler plate,$15.80

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -4,43 +4,43 @@ module Helpers
   end
 
   def set_sample_target
-    5.00
+    500
   end
 
   def set_items_and_prices
     [
-      { "mixed fruit"       => 2.15 },
-      { "golden omelette"   => 3.00 },
-      { "tatter tots"       => 2.00 },
-      { "orange juice"      => 1.00 },
-      { "morning salad"     => 1.00 },
-      { "wedged potatoes"   => 2.00 },
-      { "oatmeal"           => 6.00 }
+      { "mixed fruit"       => 215 },
+      { "golden omelette"   => 300 },
+      { "tatter tots"       => 200 },
+      { "orange juice"      => 100 },
+      { "morning salad"     => 100 },
+      { "wedged potatoes"   => 200 },
+      { "oatmeal"           => 600 }
     ]
   end
 
   def set_addtl_items_and_prices
     [
-      { "fries"               => 4.00 },
-      { "beer"                => 4.00 },
-      { "pumpkin curry pasta" => 10.00 },
-      { "pomegranate juice"   => 6.00 }
+      { "fries"               => 400 },
+      { "beer"                => 400 },
+      { "pumpkin curry pasta" => 1000 },
+      { "pomegranate juice"   => 600 }
     ]
   end
 
   def set_another_target
-    15.05
+    1505
   end
 
   def set_more_items_and_prices
     [
-      { "mixed fruit"           => 2.15 },
-      { "french fries"          => 2.75 },
-      { "side salad"            => 3.35 },
-      { "hot wings"             => 3.55 },
-      { "mozzarella sticks"     => 4.20 },
-      { "sampler plate"         => 5.80 },
-      { "larger sampler plate"  => 9.25 }
+      { "mixed fruit"           => 215 },
+      { "french fries"          => 275 },
+      { "side salad"            => 335 },
+      { "hot wings"             => 355 },
+      { "mozzarella sticks"     => 420 },
+      { "sampler plate"         => 580 },
+      { "larger sampler plate"  => 925 }
     ]
   end
 
@@ -50,8 +50,8 @@ module Helpers
 
   def happy_result
     [
-      [{ "tatter tots"=>2.0 }, { "golden omelette"=>3.0 }],
-      [{ "orange juice"=>1.0 }, { "morning salad"=>1.0 }, { "golden omelette"=>3.0 }]
+      [{ "tatter tots"=>200 }, { "golden omelette"=>300 }],
+      [{ "orange juice"=>100 }, { "morning salad"=>100 }, { "golden omelette"=>300 }]
     ]
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -50,8 +50,9 @@ module Helpers
 
   def happy_result
     [
-      [{ "tatter tots"=>200 }, { "golden omelette"=>300 }],
-      [{ "orange juice"=>100 }, { "morning salad"=>100 }, { "golden omelette"=>300 }]
+      [{1=>{"golden omelette"=>300}}, {1=>{"tatter tots"=>200}}],
+      [{5=>{"orange juice"=>100}}],
+      [{5=>{"morning salad"=>100}}]
     ]
   end
 end

--- a/spec/support/menu.txt
+++ b/spec/support/menu.txt
@@ -1,0 +1,7 @@
+$15.05
+mixed fruit,$2.15
+french fries,$2.75
+side salad,$3.35
+hot wings,$3.55
+mozzarella sticks,$4.20
+sampler plate,$5.80

--- a/spec/support/sample_menu.txt
+++ b/spec/support/sample_menu.txt
@@ -1,4 +1,4 @@
-$5.00
+$5.15
 mixed fruit,$2.15
 golden omelette,$3.00
 tatter tots,$2.00


### PR DESCRIPTION
Change PriceScanner implementation to find combinations for quantity > 1 per item to meet target price

There are a lot of iterations through collections, so want to refactor for a cleaner implementation with enhanced performance.
